### PR TITLE
refactor: move config to configs service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,17 +1,17 @@
+import Config from './services/config'
+
 import Express = require('express')
+import Reduct = require('reduct')
 
 export default class App {
   private publicApiServer: Express.Application
 
   private privateApiServer: Express.Application
 
-  private publicApiServerPort: number
+  private config: Config
 
-  private privateApiServerPort: number
-
-  constructor() {
-    this.publicApiServerPort = 8080
-    this.privateApiServerPort = 8081
+  constructor(deps: Reduct.Injector) {
+    this.config = deps(Config)
   }
 
   public async init(): Promise<void> {
@@ -28,15 +28,15 @@ export default class App {
     })
 
     const publicApi = this.publicApiServer.listen(
-      this.publicApiServerPort,
+      this.config.publicApiPort,
       () => {
-        console.log(`Public API listening on ${this.publicApiServerPort}`)
+        console.log(`Public API listening on ${this.config.publicApiPort}`)
       },
     )
     const privateApi = this.privateApiServer.listen(
-      this.privateApiServerPort,
+      this.config.privateApiPort,
       () => {
-        console.log(`Private API listening on ${this.privateApiServerPort}`)
+        console.log(`Private API listening on ${this.config.privateApiPort}`)
       },
     )
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,10 +1,5 @@
 export default class Config {
-  public privateApiPort: number
+  public publicApiPort = 8080
 
-  public publicApiPort: number
-
-  constructor() {
-    this.publicApiPort = 8080
-    this.privateApiPort = 8081
-  }
+  public privateApiPort = 8081
 }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,0 +1,10 @@
+export default class Config {
+  public privateApiPort: number
+
+  public publicApiPort: number
+
+  constructor() {
+    this.publicApiPort = 8080
+    this.privateApiPort = 8081
+  }
+}


### PR DESCRIPTION
## High Level Overview of Change

Just moving config values into a config service to manage our state in a centralized location. @hbergren I copied over some of the linting config (in the initial commit, not this PR). Would prob be worth glancing over to see if there are any issues with it.

- [x] Refactor (non-breaking change that only restructures code)
